### PR TITLE
Skip over unknown boxes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,8 @@ fn read_boxes(f: File) -> Result<BMFF> {
                 start = (size as u32 - HEADER_SIZE) as u64;
             }
             _ => {
+                // Skip over unsupported boxes, but stop if the size is zero,
+                // meaning the last box has been reached.
                 if size == 0 {
                     break;
                 } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,13 @@ fn read_boxes(f: File) -> Result<BMFF> {
             BoxType::MoofBox => {
                 start = (size as u32 - HEADER_SIZE) as u64;
             }
-            _ => break
+            _ => {
+                if size == 0 {
+                    break;
+                } else {
+                    start = (size as u32 - HEADER_SIZE) as u64;
+                }
+            }
         };
     }
     Ok(bmff)


### PR DESCRIPTION
If the box size is non-zero, skip over it and continue reading. Otherwise if
the box size is zero, exit the loop.