### PR TITLE
Remove deprecated codes

### DIFF
--- a/src/atoms.rs
+++ b/src/atoms.rs
@@ -6,97 +6,58 @@ use crate::{Error, read_box_header, BoxHeader, HEADER_SIZE};
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-#[derive(Clone, Copy, PartialEq)]
-pub enum BoxType {
-    FtypBox,
-    MvhdBox,
-    FreeBox,
-    MdatBox,
-    MoovBox,
-    MoofBox,
-    TkhdBox,
-    EdtsBox,
-    MdiaBox,
-    ElstBox,
-    MdhdBox,
-    HdlrBox,
-    MinfBox,
-    VmhdBox,
-    StblBox,
-    StsdBox,
-    SttsBox,
-    TrakBox,
-    UdtaBox,
-    DinfBox,
-    SmhdBox,
-    Avc1Box,
-    Mp4aBox,
-    UnknownBox(u32),
-}
+macro_rules! boxtype {
+    ($( $name:ident => $value:expr ),*) => {
+        #[derive(Clone, Copy, PartialEq)]
+        pub enum BoxType {
+            $( $name, )*
+            UnknownBox(u32),
+        }
 
-impl From<u32> for BoxType {
-    fn from(t: u32) -> BoxType {
-        use self::BoxType::*;
-        match t {
-            0x66747970 => FtypBox,
-            0x6d766864 => MvhdBox,
-            0x66726565 => FreeBox,
-            0x6d646174 => MdatBox,
-            0x6d6f6f76 => MoovBox,
-            0x6d6f6f66 => MoofBox ,
-            0x746b6864 => TkhdBox,
-            0x65647473 => EdtsBox,
-            0x6d646961 => MdiaBox,
-            0x656c7374 => ElstBox,
-            0x6d646864 => MdhdBox,
-            0x68646c72 => HdlrBox,
-            0x6d696e66 => MinfBox,
-            0x766d6864 => VmhdBox,
-            0x7374626c => StblBox,
-            0x73747364 => StsdBox,
-            0x73747473 => SttsBox,
-            0x7472616b => TrakBox,
-            0x75647461 => UdtaBox,
-            0x64696e66 => DinfBox,
-            0x736d6864 => SmhdBox,
-            0x61766331 => Avc1Box,
-            0x6d703461 => Mp4aBox,
-            _ => UnknownBox(t),
+        impl From<u32> for BoxType {
+            fn from(t: u32) -> BoxType {
+                match t {
+                    $( $value => BoxType::$name, )*
+                    _ => BoxType::UnknownBox(t),
+                }
+            }
+        }
+        
+        impl Into<u32> for BoxType {
+            fn into(self) -> u32 {
+                match self {
+                    $( BoxType::$name => $value, )*
+                    BoxType::UnknownBox(t) => t,
+                }
+            }
         }
     }
 }
 
-impl Into<u32> for BoxType {
-    fn into(self) -> u32 {
-        use self::BoxType::*;
-        match self {
-            FtypBox => 0x66747970,
-            MvhdBox => 0x6d766864,
-            FreeBox => 0x66726565,
-            MdatBox => 0x6d646174,
-            MoovBox => 0x6d6f6f76,
-            MoofBox => 0x6d6f6f66,
-            TkhdBox => 0x746b6864,
-            EdtsBox => 0x65647473,
-            MdiaBox => 0x6d646961,
-            ElstBox => 0x656c7374,
-            MdhdBox => 0x6d646864,
-            HdlrBox => 0x68646c72,
-            MinfBox => 0x6d696e66,
-            VmhdBox => 0x766d6864,
-            StblBox => 0x7374626c,
-            StsdBox => 0x73747364,
-            SttsBox => 0x73747473,
-            TrakBox => 0x7472616b,
-            UdtaBox => 0x75647461,
-            DinfBox => 0x64696e66,
-            SmhdBox => 0x736d6864,
-            Avc1Box => 0x61766331,
-            Mp4aBox => 0x6d703461,
-
-            UnknownBox(t) => t,
-        }
-    }
+boxtype!{
+    FtypBox => 0x66747970,
+    MvhdBox => 0x6d766864,
+    FreeBox => 0x66726565,
+    MdatBox => 0x6d646174,
+    MoovBox => 0x6d6f6f76,
+    MoofBox => 0x6d6f6f66,
+    TkhdBox => 0x746b6864,
+    EdtsBox => 0x65647473,
+    MdiaBox => 0x6d646961,
+    ElstBox => 0x656c7374,
+    MdhdBox => 0x6d646864,
+    HdlrBox => 0x68646c72,
+    MinfBox => 0x6d696e66,
+    VmhdBox => 0x766d6864,
+    StblBox => 0x7374626c,
+    StsdBox => 0x73747364,
+    SttsBox => 0x73747473,
+    TrakBox => 0x7472616b,
+    UdtaBox => 0x75647461,
+    DinfBox => 0x64696e66,
+    SmhdBox => 0x736d6864,
+    Avc1Box => 0x61766331,
+    Mp4aBox => 0x6d703461
 }
 
 impl fmt::Debug for BoxType {

--- a/src/atoms.rs
+++ b/src/atoms.rs
@@ -34,6 +34,16 @@ macro_rules! boxtype {
     }
 }
 
+macro_rules! read_box_header_ext {
+    ($r:ident, $v:ident, $ f:ident) => {
+        let $v = $r.read_u8().unwrap();
+        let flags_a = $r.read_u8().unwrap();
+        let flags_b = $r.read_u8().unwrap();
+        let flags_c = $r.read_u8().unwrap();
+        let $f = u32::from(flags_a) << 16 | u32::from(flags_b) << 8 | u32::from(flags_c);
+    }
+}
+
 boxtype!{
     FtypBox => 0x66747970,
     MvhdBox => 0x6d766864,
@@ -349,11 +359,8 @@ impl<R: Read + Seek> ReadBox<&mut BufReader<R>> for MvhdBox {
     fn read_box(reader: &mut BufReader<R>, size: u32) -> Result<Self> {
         let current =  reader.seek(SeekFrom::Current(0)).unwrap(); // Current cursor position.
 
-        let version = reader.read_u8().unwrap();
-        let flags_a = reader.read_u8().unwrap();
-        let flags_b = reader.read_u8().unwrap();
-        let flags_c = reader.read_u8().unwrap();
-        let flags = u32::from(flags_a) << 16 | u32::from(flags_b) << 8 | u32::from(flags_c);
+        read_box_header_ext!(reader, version, flags);
+
         let creation_time = reader.read_u32::<BigEndian>().unwrap();
         let modification_time = reader.read_u32::<BigEndian>().unwrap();
         let timescale = reader.read_u32::<BigEndian>().unwrap();
@@ -410,11 +417,8 @@ impl<R: Read + Seek> ReadBox<&mut BufReader<R>> for TkhdBox {
     fn read_box(reader: &mut BufReader<R>, size: u32) -> Result<Self> {
         let current =  reader.seek(SeekFrom::Current(0)).unwrap(); // Current cursor position.
 
-        let version = reader.read_u8().unwrap();
-        let flags_a = reader.read_u8().unwrap();
-        let flags_b = reader.read_u8().unwrap();
-        let flags_c = reader.read_u8().unwrap();
-        let flags = u32::from(flags_a) << 16 | u32::from(flags_b) << 8 | u32::from(flags_c);
+        read_box_header_ext!(reader, version, flags);
+
         let creation_time = reader.read_u32::<BigEndian>().unwrap();
         let modification_time = reader.read_u32::<BigEndian>().unwrap();
         let track_id = reader.read_u32::<BigEndian>().unwrap();
@@ -548,11 +552,8 @@ impl<R: Read + Seek> ReadBox<&mut BufReader<R>> for MdhdBox {
     fn read_box(reader: &mut BufReader<R>, size: u32) -> Result<Self> {
         let current = reader.seek(SeekFrom::Current(0)).unwrap(); // Current cursor position.
 
-        let version = reader.read_u8().unwrap();
-        let flags_a = reader.read_u8().unwrap();
-        let flags_b = reader.read_u8().unwrap();
-        let flags_c = reader.read_u8().unwrap();
-        let flags = u32::from(flags_a) << 16 | u32::from(flags_b) << 8 | u32::from(flags_c);
+        read_box_header_ext!(reader, version, flags);
+
         let creation_time = reader.read_u32::<BigEndian>().unwrap();
         let modification_time = reader.read_u32::<BigEndian>().unwrap();
         let timescale = reader.read_u32::<BigEndian>().unwrap();
@@ -593,11 +594,8 @@ impl<R: Read + Seek> ReadBox<&mut BufReader<R>> for HdlrBox {
     fn read_box(reader: &mut BufReader<R>, size: u32) -> Result<Self> {
         let current = reader.seek(SeekFrom::Current(0)).unwrap(); // Current cursor position.
 
-        let version = reader.read_u8().unwrap();
-        let flags_a = reader.read_u8().unwrap();
-        let flags_b = reader.read_u8().unwrap();
-        let flags_c = reader.read_u8().unwrap();
-        let flags = u32::from(flags_a) << 16 | u32::from(flags_b) << 8 | u32::from(flags_c);
+        read_box_header_ext!(reader, version, flags);
+
         reader.read_u32::<BigEndian>().unwrap(); // skip.
         let handler = reader.read_u32::<BigEndian>().unwrap();
 
@@ -660,11 +658,8 @@ impl<R: Read + Seek> ReadBox<&mut BufReader<R>> for VmhdBox {
     fn read_box(reader: &mut BufReader<R>, size: u32) -> Result<Self> {
         let current = reader.seek(SeekFrom::Current(0)).unwrap(); // Current cursor position.
 
-        let version = reader.read_u8().unwrap();
-        let flags_a = reader.read_u8().unwrap();
-        let flags_b = reader.read_u8().unwrap();
-        let flags_c = reader.read_u8().unwrap();
-        let flags = u32::from(flags_a) << 16 | u32::from(flags_b) << 8 | u32::from(flags_c);
+        read_box_header_ext!(reader, version, flags);
+
         let graphics_mode = reader.read_u16::<BigEndian>().unwrap();
         let op_color = reader.read_u16::<BigEndian>().unwrap();
         skip(reader, current, size);
@@ -708,11 +703,8 @@ impl<R: Read + Seek> ReadBox<&mut BufReader<R>> for SttsBox {
     fn read_box(reader: &mut BufReader<R>, size: u32) -> Result<Self> { 
         let current = reader.seek(SeekFrom::Current(0)).unwrap(); // Current cursor position.
 
-        let version = reader.read_u8().unwrap();
-        let flags_a = reader.read_u8().unwrap();
-        let flags_b = reader.read_u8().unwrap();
-        let flags_c = reader.read_u8().unwrap();
-        let flags = u32::from(flags_a) << 16 | u32::from(flags_b) << 8 | u32::from(flags_c);
+        read_box_header_ext!(reader, version, flags);
+
         let entry_count = reader.read_u32::<BigEndian>().unwrap();
         let mut sample_counts = Vec::new();
         let mut sample_deltas = Vec::new();
@@ -739,11 +731,8 @@ impl<R: Read + Seek> ReadBox<&mut BufReader<R>> for StsdBox {
     fn read_box(reader: &mut BufReader<R>, size: u32) -> Result<Self> {
         let current = reader.seek(SeekFrom::Current(0)).unwrap(); // Current cursor position.
 
-        let version = reader.read_u8().unwrap();
-        let flags_a = reader.read_u8().unwrap();
-        let flags_b = reader.read_u8().unwrap();
-        let flags_c = reader.read_u8().unwrap();
-        let flags = u32::from(flags_a) << 16 | u32::from(flags_b) << 8 | u32::from(flags_c);
+        read_box_header_ext!(reader, version, flags);
+
         reader.read_u32::<BigEndian>().unwrap(); // skip.
 
         let mut start = 0u64;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@ fn read_boxes(f: File) -> Result<BMFF> {
         // Match and parse the atom boxes.
         match name {
             BoxType::FtypBox => {
-                let ftyp = parse_ftyp_box(&mut reader, 0, size as u32).unwrap();
+                let ftyp = FtypBox::read_box(&mut reader, 0, size as u32).unwrap();
                 bmff.ftyp = ftyp;
             }
             BoxType::FreeBox => {
@@ -77,7 +77,7 @@ fn read_boxes(f: File) -> Result<BMFF> {
                 start = (size as u32 - HEADER_SIZE) as u64;
             }
             BoxType::MoovBox => {
-                let moov = parse_moov_box(&mut reader, 0, size as u32).unwrap();
+                let moov = MoovBox::read_box(&mut reader, 0, size as u32).unwrap();
                 bmff.moov = Some(moov);
             }
             BoxType::MoofBox => {
@@ -97,7 +97,7 @@ fn read_boxes(f: File) -> Result<BMFF> {
     Ok(bmff)
 }
 
-fn read_box_header(reader: &mut BufReader<File>, start: u64) -> Result<BoxHeader> {
+fn read_box_header<R: Read + Seek>(reader: &mut BufReader<R>, start: u64) -> Result<BoxHeader> {
     // Seek to offset.
     let _r = reader.seek(SeekFrom::Current(start as i64));
 


### PR DESCRIPTION
- Add `boxtype` macro that can easily add new box type.
- Add `read_box_header_ext` macro that adds codes reading version and flags
- Fix parsing error when box has largesize