### PR TITLE
Mp4Reader and update README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,22 +10,47 @@ ISO/IEC 14496-12 - ISO Base Media File Format (QuickTime, MPEG-4, etc)
 
 #### Example
 ```rust
-use mp4;
+use std::fs::File;
+use std::io::{BufReader};
+use mp4::{Result};
 
-fn main() {
-    let f = File::open("example.mp4").unwrap();
+fn main() -> Result<()> {
+    let f = File::open("tears-of-steel-2s.mp4").unwrap();
     let size = f.metadata()?.len();
     let reader = BufReader::new(f);
 
-    let mut mp4 = Mp4Reader::new(reader);
-    mp4.read(size)?;
+    let mp4 = mp4::Mp4Reader::read_header(reader, size)?;
 
+    // Print boxes.
+    println!("major brand: {}", mp4.ftyp.major_brand);
+    println!("timescale: {}", mp4.moov.mvhd.timescale);
+
+    // Use available methods.
     println!("size: {}", mp4.size());
-    println!("brands: {:?} {:?}\n", mp4.ftyp.major_brand, mp4.ftyp.compatible_brands);
+
+    let mut compatible_brands = String::new();
+    for brand in mp4.compatible_brands().iter() {
+        compatible_brands.push_str(&brand.to_string());
+        compatible_brands.push_str(",");
+    }
+    println!("compatible brands: {}", compatible_brands);
+    println!("duration: {:?}", mp4.duration());
+
+    // Track info.
+    for track in mp4.tracks().iter() {
+        println!(
+            "track: #{}({}) {} : {}",
+            track.track_id(),
+            track.language(),
+            track.track_type()?,
+            track.box_type()?,
+        );
+    }
+    Ok(())
 }
 ```
 
-See [examples/](examples/) for a full example.
+See [examples/](examples/) for more examples.
 
 #### Documentation
 * https://docs.rs/mp4/

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ use std::io::{BufReader};
 use mp4::{Result};
 
 fn main() -> Result<()> {
-    let f = File::open("tears-of-steel-2s.mp4").unwrap();
+    let f = File::open("example.mp4").unwrap();
     let size = f.metadata()?.len();
     let reader = BufReader::new(f);
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -7,8 +7,8 @@ use crate::*;
 #[derive(Debug)]
 pub struct Mp4Reader<R> {
     reader: R,
-    ftyp: FtypBox,
-    moov: MoovBox,
+    pub ftyp: FtypBox,
+    pub moov: MoovBox,
 
     tracks: Vec<Mp4Track>,
     size: u64,


### PR DESCRIPTION
`ftyp` and `moov` should be public in the Mp4Reader for access, like the other boxes.