### PR TITLE
Mp4dump example

### DIFF
--- a/examples/mp4dump.rs
+++ b/examples/mp4dump.rs
@@ -1,0 +1,90 @@
+use std::env;
+use std::fs::File;
+use std::io::prelude::*;
+use std::io::{self, BufReader};
+use std::path::Path;
+
+use mp4::{Result};
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+
+    if args.len() < 2 {
+        println!("Usage: mp4dump <filename>");
+        std::process::exit(1);
+    }
+
+    if let Err(err) = dump(&args[1]) {
+        let _ = writeln!(io::stderr(), "{}", err);
+    }
+}
+
+fn dump<P: AsRef<Path>>(filename: &P) -> Result<()> {
+    let f = File::open(filename)?;
+    let size = f.metadata()?.len();
+    let reader = BufReader::new(f);
+
+    let mp4 = mp4::Mp4Reader::read_header(reader, size)?;
+
+    // ftyp
+    println!("[{}] size={} ", mp4.ftyp.get_type(), mp4.ftyp.get_size());
+
+    // moov
+    println!("[{}] size={} ", mp4.moov.get_type(), mp4.moov.get_size());
+    println!("  [{}] size={} ", mp4.moov.mvhd.get_type(), mp4.moov.mvhd.get_size());
+
+    // Tracks.
+    for track in mp4.tracks().iter() {
+
+        // trak
+        println!("  [{}] size={} ", track.trak.get_type(), track.trak.get_size());
+        println!("    [{}] size={} ", track.trak.tkhd.get_type(), track.trak.tkhd.get_size());
+        if let Some(ref edts) = track.trak.edts {
+            println!("    [{}] size={} ", edts.get_type(), edts.get_size());
+            if let Some(ref elst) = edts.elst {
+                println!("      [{}] size={} ", elst.get_type(), elst.get_size());
+            }
+        }
+
+        // trak.mdia.
+        println!("    [{}] size={} ", track.trak.mdia.get_type(), track.trak.mdia.get_size());
+        println!("      [{}] size={} ", track.trak.mdia.mdhd.get_type(), track.trak.mdia.mdhd.get_size());
+        println!("      [{}] size={} ", track.trak.mdia.hdlr.get_type(), track.trak.mdia.hdlr.get_size());
+        println!("      [{}] size={} ", track.trak.mdia.minf.get_type(), track.trak.mdia.minf.get_size());
+
+        // trak.mdia.minf
+        if let Some(ref vmhd) = track.trak.mdia.minf.vmhd {
+            println!("        [{}] size={} ", vmhd.get_type(), vmhd.get_size());
+        }
+        if let Some(ref smhd) = track.trak.mdia.minf.smhd {
+            println!("        [{}] size={} ", smhd.get_type(), smhd.get_size());
+        }
+
+        // trak.mdia.minf.stbl
+        println!("      [{}] size={} ", track.trak.mdia.minf.stbl.get_type(), track.trak.mdia.minf.stbl.get_size());
+        println!("        [{}] size={} ", track.trak.mdia.minf.stbl.stsd.get_type(), track.trak.mdia.minf.stbl.stsd.get_size());
+        if let Some(ref avc1) = track.trak.mdia.minf.stbl.stsd.avc1 {
+            println!("          [{}] size={} ", avc1.get_type(), avc1.get_size());
+        }
+        if let Some(ref mp4a) = track.trak.mdia.minf.stbl.stsd.mp4a {
+            println!("          [{}] size={} ", mp4a.get_type(), mp4a.get_size());
+        }
+        println!("        [{}] size={} ", track.trak.mdia.minf.stbl.stts.get_type(), track.trak.mdia.minf.stbl.stts.get_size());
+        if let Some(ref ctts) = track.trak.mdia.minf.stbl.ctts {
+            println!("        [{}] size={} ", ctts.get_type(), ctts.get_size());
+        }
+        if let Some(ref stss) = track.trak.mdia.minf.stbl.stss {
+            println!("        [{}] size={} ", stss.get_type(), stss.get_size());
+        }
+        println!("        [{}] size={} ", track.trak.mdia.minf.stbl.stsc.get_type(), track.trak.mdia.minf.stbl.stsc.get_size());
+        println!("        [{}] size={} ", track.trak.mdia.minf.stbl.stsz.get_type(), track.trak.mdia.minf.stbl.stsz.get_size());
+        if let Some(ref stco) = track.trak.mdia.minf.stbl.stco {
+            println!("        [{}] size={} ", stco.get_type(), stco.get_size());
+        }
+        if let Some(ref co64) = track.trak.mdia.minf.stbl.co64 {
+            println!("        [{}] size={} ", co64.get_type(), co64.get_size());
+        }
+    }
+
+    Ok(())
+}

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,0 +1,27 @@
+use mp4;
+use std::env;
+use std::fs::File;
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+
+    if args.len() < 2 {
+        println!("Usage: mp4dump <filename>");
+        std::process::exit(1);
+    }
+
+    let filename = &args[1];
+    let f = File::open(filename).unwrap();
+    let mp4 = mp4::read_mp4(f).unwrap();
+
+    println!("Major Brand: {}", mp4.major_brand());
+
+    for track in mp4.tracks().iter() {
+        println!("Track: #{}({}) {} {}",
+            track.track_id(),
+            track.language(),
+            track.track_type().unwrap(),
+            track.box_type().unwrap(),
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ mod types;
 pub use types::*;
 
 mod mp4box;
+pub use mp4box::{Mp4Box};
 
 mod track;
 pub use track::{Mp4Track, TrackConfig};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+use std::io::{BufReader};
+use std::fs::File;
+
 mod error;
 pub use error::Error;
 
@@ -17,3 +20,10 @@ pub use reader::Mp4Reader;
 
 mod writer;
 pub use writer::{Mp4Config, Mp4Writer};
+
+pub fn read_mp4(f: File) -> Result<Mp4Reader<BufReader<File>>> {
+    let size = f.metadata()?.len();
+    let reader = BufReader::new(f);
+    let mp4 = reader::Mp4Reader::read_header(reader, size)?;
+    Ok(mp4)
+}

--- a/src/mp4box/avc1.rs
+++ b/src/mp4box/avc1.rs
@@ -43,6 +43,14 @@ impl Avc1Box {
             avcc: AvcCBox::new(&config.seq_param_set, &config.pic_param_set),
         }
     }
+
+    pub fn get_type(&self) -> BoxType {
+        BoxType::Avc1Box
+    }
+
+    pub fn get_size(&self) -> u64 {
+        HEADER_SIZE + 8 + 70 + self.avcc.box_size()
+    }
 }
 
 impl Mp4Box for Avc1Box {

--- a/src/mp4box/avc1.rs
+++ b/src/mp4box/avc1.rs
@@ -54,7 +54,7 @@ impl Avc1Box {
 }
 
 impl Mp4Box for Avc1Box {
-    fn box_type() -> BoxType {
+    fn box_type(&self) -> BoxType {
         BoxType::Avc1Box
     }
 
@@ -110,7 +110,7 @@ impl<R: Read + Seek> ReadBox<&mut R> for Avc1Box {
 impl<W: Write> WriteBox<&mut W> for Avc1Box {
     fn write_box(&self, writer: &mut W) -> Result<u64> {
         let size = self.box_size();
-        BoxHeader::new(Self::box_type(), size).write(writer)?;
+        BoxHeader::new(self.box_type(), size).write(writer)?;
 
         writer.write_u32::<BigEndian>(0)?; // reserved
         writer.write_u16::<BigEndian>(0)?; // reserved
@@ -162,7 +162,7 @@ impl AvcCBox {
 }
 
 impl Mp4Box for AvcCBox {
-    fn box_type() -> BoxType {
+    fn box_type(&self) -> BoxType {
         BoxType::AvcCBox
     }
 
@@ -217,7 +217,7 @@ impl<R: Read + Seek> ReadBox<&mut R> for AvcCBox {
 impl<W: Write> WriteBox<&mut W> for AvcCBox {
     fn write_box(&self, writer: &mut W) -> Result<u64> {
         let size = self.box_size();
-        BoxHeader::new(Self::box_type(), size).write(writer)?;
+        BoxHeader::new(self.box_type(), size).write(writer)?;
 
         writer.write_u8(self.configuration_version)?;
         writer.write_u8(self.avc_profile_indication)?;

--- a/src/mp4box/avc1.rs
+++ b/src/mp4box/avc1.rs
@@ -55,11 +55,11 @@ impl Avc1Box {
 
 impl Mp4Box for Avc1Box {
     fn box_type(&self) -> BoxType {
-        BoxType::Avc1Box
+        return self.get_type();
     }
 
     fn box_size(&self) -> u64 {
-        HEADER_SIZE + 8 + 70 + self.avcc.box_size()
+        return self.get_size();
     }
 }
 

--- a/src/mp4box/co64.rs
+++ b/src/mp4box/co64.rs
@@ -10,6 +10,16 @@ pub struct Co64Box {
     pub entries: Vec<u64>,
 }
 
+impl Co64Box {
+    pub fn get_type(&self) -> BoxType {
+        BoxType::Co64Box
+    }
+
+    pub fn get_size(&self) -> u64 {
+        HEADER_SIZE + HEADER_EXT_SIZE + 4 + (8 * self.entries.len() as u64)
+    }
+}
+
 impl Mp4Box for Co64Box {
     fn box_type() -> BoxType {
         BoxType::Co64Box

--- a/src/mp4box/co64.rs
+++ b/src/mp4box/co64.rs
@@ -21,7 +21,7 @@ impl Co64Box {
 }
 
 impl Mp4Box for Co64Box {
-    fn box_type() -> BoxType {
+    fn box_type(&self) -> BoxType {
         BoxType::Co64Box
     }
 
@@ -56,7 +56,7 @@ impl<R: Read + Seek> ReadBox<&mut R> for Co64Box {
 impl<W: Write> WriteBox<&mut W> for Co64Box {
     fn write_box(&self, writer: &mut W) -> Result<u64> {
         let size = self.box_size();
-        BoxHeader::new(Self::box_type(), size).write(writer)?;
+        BoxHeader::new(self.box_type(), size).write(writer)?;
 
         write_box_header_ext(writer, self.version, self.flags)?;
 

--- a/src/mp4box/co64.rs
+++ b/src/mp4box/co64.rs
@@ -22,11 +22,11 @@ impl Co64Box {
 
 impl Mp4Box for Co64Box {
     fn box_type(&self) -> BoxType {
-        BoxType::Co64Box
+        return self.get_type();
     }
 
     fn box_size(&self) -> u64 {
-        HEADER_SIZE + HEADER_EXT_SIZE + 4 + (8 * self.entries.len() as u64)
+        return self.get_size();
     }
 }
 

--- a/src/mp4box/ctts.rs
+++ b/src/mp4box/ctts.rs
@@ -10,6 +10,16 @@ pub struct CttsBox {
     pub entries: Vec<CttsEntry>,
 }
 
+impl CttsBox {
+    pub fn get_type(&self) -> BoxType {
+        BoxType::CttsBox
+    }
+
+    pub fn get_size(&self) -> u64 {
+        HEADER_SIZE + HEADER_EXT_SIZE + 4 + (8 * self.entries.len() as u64)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct CttsEntry {
     pub sample_count: u32,

--- a/src/mp4box/ctts.rs
+++ b/src/mp4box/ctts.rs
@@ -28,11 +28,11 @@ pub struct CttsEntry {
 
 impl Mp4Box for CttsBox {
     fn box_type(&self) -> BoxType {
-        BoxType::CttsBox
+        return self.get_type();
     }
 
     fn box_size(&self) -> u64 {
-        HEADER_SIZE + HEADER_EXT_SIZE + 4 + (8 * self.entries.len() as u64)
+        return self.get_size();
     }
 }
 

--- a/src/mp4box/ctts.rs
+++ b/src/mp4box/ctts.rs
@@ -27,7 +27,7 @@ pub struct CttsEntry {
 }
 
 impl Mp4Box for CttsBox {
-    fn box_type() -> BoxType {
+    fn box_type(&self) -> BoxType {
         BoxType::CttsBox
     }
 
@@ -65,7 +65,7 @@ impl<R: Read + Seek> ReadBox<&mut R> for CttsBox {
 impl<W: Write> WriteBox<&mut W> for CttsBox {
     fn write_box(&self, writer: &mut W) -> Result<u64> {
         let size = self.box_size();
-        BoxHeader::new(Self::box_type(), size).write(writer)?;
+        BoxHeader::new(self.box_type(), size).write(writer)?;
 
         write_box_header_ext(writer, self.version, self.flags)?;
 

--- a/src/mp4box/edts.rs
+++ b/src/mp4box/edts.rs
@@ -28,15 +28,11 @@ impl EdtsBox {
 
 impl Mp4Box for EdtsBox {
     fn box_type(&self) -> BoxType {
-        BoxType::EdtsBox
+        return self.get_type();
     }
 
     fn box_size(&self) -> u64 {
-        let mut size = HEADER_SIZE;
-        if let Some(ref elst) = self.elst {
-            size += elst.box_size();
-        }
-        size
+        return self.get_size();
     }
 }
 

--- a/src/mp4box/edts.rs
+++ b/src/mp4box/edts.rs
@@ -27,7 +27,7 @@ impl EdtsBox {
 }
 
 impl Mp4Box for EdtsBox {
-    fn box_type() -> BoxType {
+    fn box_type(&self) -> BoxType {
         BoxType::EdtsBox
     }
 
@@ -66,7 +66,7 @@ impl<R: Read + Seek> ReadBox<&mut R> for EdtsBox {
 impl<W: Write> WriteBox<&mut W> for EdtsBox {
     fn write_box(&self, writer: &mut W) -> Result<u64> {
         let size = self.box_size();
-        BoxHeader::new(Self::box_type(), size).write(writer)?;
+        BoxHeader::new(self.box_type(), size).write(writer)?;
 
         if let Some(ref elst) = self.elst {
             elst.write_box(writer)?;

--- a/src/mp4box/edts.rs
+++ b/src/mp4box/edts.rs
@@ -12,6 +12,18 @@ impl EdtsBox {
     pub(crate) fn new() -> EdtsBox {
         Default::default()
     }
+
+    pub fn get_type(&self) -> BoxType {
+        BoxType::EdtsBox
+    }
+
+    pub fn get_size(&self) -> u64 {
+        let mut size = HEADER_SIZE;
+        if let Some(ref elst) = self.elst {
+            size += elst.box_size();
+        }
+        size
+    }
 }
 
 impl Mp4Box for EdtsBox {

--- a/src/mp4box/elst.rs
+++ b/src/mp4box/elst.rs
@@ -18,6 +18,23 @@ pub struct ElstEntry {
     pub media_rate_fraction: u16,
 }
 
+impl ElstBox {
+    pub fn get_type(&self) -> BoxType {
+        BoxType::ElstBox
+    }
+
+    pub fn get_size(&self) -> u64 {
+        let mut size = HEADER_SIZE + HEADER_EXT_SIZE + 4;
+        if self.version == 1 {
+            size += self.entries.len() as u64 * 20;
+        } else {
+            assert_eq!(self.version, 0);
+            size += self.entries.len() as u64 * 12;
+        }
+        size
+    }
+}
+
 impl Mp4Box for ElstBox {
     fn box_type() -> BoxType {
         BoxType::ElstBox

--- a/src/mp4box/elst.rs
+++ b/src/mp4box/elst.rs
@@ -37,18 +37,11 @@ impl ElstBox {
 
 impl Mp4Box for ElstBox {
     fn box_type(&self) -> BoxType {
-        BoxType::ElstBox
+        return self.get_type();
     }
 
     fn box_size(&self) -> u64 {
-        let mut size = HEADER_SIZE + HEADER_EXT_SIZE + 4;
-        if self.version == 1 {
-            size += self.entries.len() as u64 * 20;
-        } else {
-            assert_eq!(self.version, 0);
-            size += self.entries.len() as u64 * 12;
-        }
-        size
+        return self.get_size();
     }
 }
 

--- a/src/mp4box/elst.rs
+++ b/src/mp4box/elst.rs
@@ -36,7 +36,7 @@ impl ElstBox {
 }
 
 impl Mp4Box for ElstBox {
-    fn box_type() -> BoxType {
+    fn box_type(&self) -> BoxType {
         BoxType::ElstBox
     }
 
@@ -95,7 +95,7 @@ impl<R: Read + Seek> ReadBox<&mut R> for ElstBox {
 impl<W: Write> WriteBox<&mut W> for ElstBox {
     fn write_box(&self, writer: &mut W) -> Result<u64> {
         let size = self.box_size();
-        BoxHeader::new(Self::box_type(), size).write(writer)?;
+        BoxHeader::new(self.box_type(), size).write(writer)?;
 
         write_box_header_ext(writer, self.version, self.flags)?;
 

--- a/src/mp4box/ftyp.rs
+++ b/src/mp4box/ftyp.rs
@@ -21,7 +21,7 @@ impl FtypBox {
 }
 
 impl Mp4Box for FtypBox {
-    fn box_type() -> BoxType {
+    fn box_type(&self) -> BoxType {
         BoxType::FtypBox
     }
 
@@ -60,7 +60,7 @@ impl<R: Read + Seek> ReadBox<&mut R> for FtypBox {
 impl<W: Write> WriteBox<&mut W> for FtypBox {
     fn write_box(&self, writer: &mut W) -> Result<u64> {
         let size = self.box_size();
-        BoxHeader::new(Self::box_type(), size).write(writer)?;
+        BoxHeader::new(self.box_type(), size).write(writer)?;
 
         writer.write_u32::<BigEndian>((&self.major_brand).into())?;
         writer.write_u32::<BigEndian>(self.minor_version)?;

--- a/src/mp4box/ftyp.rs
+++ b/src/mp4box/ftyp.rs
@@ -22,11 +22,11 @@ impl FtypBox {
 
 impl Mp4Box for FtypBox {
     fn box_type(&self) -> BoxType {
-        BoxType::FtypBox
+        return self.get_type();
     }
 
     fn box_size(&self) -> u64 {
-        HEADER_SIZE + 8 + (4 * self.compatible_brands.len() as u64)
+        return self.get_size();
     }
 }
 

--- a/src/mp4box/ftyp.rs
+++ b/src/mp4box/ftyp.rs
@@ -10,6 +10,16 @@ pub struct FtypBox {
     pub compatible_brands: Vec<FourCC>,
 }
 
+impl FtypBox {
+    pub fn get_type(&self) -> BoxType {
+        BoxType::FtypBox
+    }
+
+    pub fn get_size(&self) -> u64 {
+        HEADER_SIZE + 8 + (4 * self.compatible_brands.len() as u64)
+    }
+}
+
 impl Mp4Box for FtypBox {
     fn box_type() -> BoxType {
         BoxType::FtypBox

--- a/src/mp4box/hdlr.rs
+++ b/src/mp4box/hdlr.rs
@@ -22,7 +22,7 @@ impl HdlrBox {
 }
 
 impl Mp4Box for HdlrBox {
-    fn box_type() -> BoxType {
+    fn box_type(&self) -> BoxType {
         BoxType::HdlrBox
     }
 
@@ -68,7 +68,7 @@ impl<R: Read + Seek> ReadBox<&mut R> for HdlrBox {
 impl<W: Write> WriteBox<&mut W> for HdlrBox {
     fn write_box(&self, writer: &mut W) -> Result<u64> {
         let size = self.box_size();
-        BoxHeader::new(Self::box_type(), size).write(writer)?;
+        BoxHeader::new(self.box_type(), size).write(writer)?;
 
         write_box_header_ext(writer, self.version, self.flags)?;
 

--- a/src/mp4box/hdlr.rs
+++ b/src/mp4box/hdlr.rs
@@ -23,11 +23,11 @@ impl HdlrBox {
 
 impl Mp4Box for HdlrBox {
     fn box_type(&self) -> BoxType {
-        BoxType::HdlrBox
+        return self.get_type();
     }
 
     fn box_size(&self) -> u64 {
-        HEADER_SIZE + HEADER_EXT_SIZE + 20 + self.name.len() as u64 + 1
+        return self.get_size();
     }
 }
 

--- a/src/mp4box/hdlr.rs
+++ b/src/mp4box/hdlr.rs
@@ -11,6 +11,16 @@ pub struct HdlrBox {
     pub name: String,
 }
 
+impl HdlrBox {
+    pub fn get_type(&self) -> BoxType {
+        BoxType::HdlrBox
+    }
+
+    pub fn get_size(&self) -> u64 {
+        HEADER_SIZE + HEADER_EXT_SIZE + 20 + self.name.len() as u64 + 1
+    }
+}
+
 impl Mp4Box for HdlrBox {
     fn box_type() -> BoxType {
         BoxType::HdlrBox

--- a/src/mp4box/mdhd.rs
+++ b/src/mp4box/mdhd.rs
@@ -50,20 +50,11 @@ impl Default for MdhdBox {
 
 impl Mp4Box for MdhdBox {
     fn box_type(&self) -> BoxType {
-        BoxType::MdhdBox
+        return self.get_type();
     }
 
     fn box_size(&self) -> u64 {
-        let mut size = HEADER_SIZE + HEADER_EXT_SIZE;
-
-        if self.version == 1 {
-            size += 28;
-        } else {
-            assert_eq!(self.version, 0);
-            size += 16;
-        }
-        size += 4;
-        size
+        return self.get_size();
     }
 }
 

--- a/src/mp4box/mdhd.rs
+++ b/src/mp4box/mdhd.rs
@@ -49,7 +49,7 @@ impl Default for MdhdBox {
 }
 
 impl Mp4Box for MdhdBox {
-    fn box_type() -> BoxType {
+    fn box_type(&self) -> BoxType {
         BoxType::MdhdBox
     }
 
@@ -109,7 +109,7 @@ impl<R: Read + Seek> ReadBox<&mut R> for MdhdBox {
 impl<W: Write> WriteBox<&mut W> for MdhdBox {
     fn write_box(&self, writer: &mut W) -> Result<u64> {
         let size = self.box_size();
-        BoxHeader::new(Self::box_type(), size).write(writer)?;
+        BoxHeader::new(self.box_type(), size).write(writer)?;
 
         write_box_header_ext(writer, self.version, self.flags)?;
 

--- a/src/mp4box/mdhd.rs
+++ b/src/mp4box/mdhd.rs
@@ -15,6 +15,25 @@ pub struct MdhdBox {
     pub language: String,
 }
 
+impl MdhdBox {
+    pub fn get_type(&self) -> BoxType {
+        BoxType::MdhdBox
+    }
+
+    pub fn get_size(&self) -> u64 {
+        let mut size = HEADER_SIZE + HEADER_EXT_SIZE;
+
+        if self.version == 1 {
+            size += 28;
+        } else {
+            assert_eq!(self.version, 0);
+            size += 16;
+        }
+        size += 4;
+        size
+    }
+}
+
 impl Default for MdhdBox {
     fn default() -> Self {
         MdhdBox {

--- a/src/mp4box/mdia.rs
+++ b/src/mp4box/mdia.rs
@@ -10,6 +10,16 @@ pub struct MdiaBox {
     pub minf: MinfBox,
 }
 
+impl MdiaBox {
+    pub fn get_type(&self) -> BoxType {
+        BoxType::MdiaBox
+    }
+
+    pub fn get_size(&self) -> u64 {
+        HEADER_SIZE + self.mdhd.box_size() + self.hdlr.box_size() + self.minf.box_size()
+    }
+}
+
 impl Mp4Box for MdiaBox {
     fn box_type() -> BoxType {
         BoxType::MdiaBox

--- a/src/mp4box/mdia.rs
+++ b/src/mp4box/mdia.rs
@@ -21,7 +21,7 @@ impl MdiaBox {
 }
 
 impl Mp4Box for MdiaBox {
-    fn box_type() -> BoxType {
+    fn box_type(&self) -> BoxType {
         BoxType::MdiaBox
     }
 
@@ -87,7 +87,7 @@ impl<R: Read + Seek> ReadBox<&mut R> for MdiaBox {
 impl<W: Write> WriteBox<&mut W> for MdiaBox {
     fn write_box(&self, writer: &mut W) -> Result<u64> {
         let size = self.box_size();
-        BoxHeader::new(Self::box_type(), size).write(writer)?;
+        BoxHeader::new(self.box_type(), size).write(writer)?;
 
         self.mdhd.write_box(writer)?;
         self.hdlr.write_box(writer)?;

--- a/src/mp4box/mdia.rs
+++ b/src/mp4box/mdia.rs
@@ -22,11 +22,11 @@ impl MdiaBox {
 
 impl Mp4Box for MdiaBox {
     fn box_type(&self) -> BoxType {
-        BoxType::MdiaBox
+        return self.get_type();
     }
 
     fn box_size(&self) -> u64 {
-        HEADER_SIZE + self.mdhd.box_size() + self.hdlr.box_size() + self.minf.box_size()
+        return self.get_size();
     }
 }
 

--- a/src/mp4box/minf.rs
+++ b/src/mp4box/minf.rs
@@ -29,7 +29,7 @@ impl MinfBox {
 }
 
 impl Mp4Box for MinfBox {
-    fn box_type() -> BoxType {
+    fn box_type(&self) -> BoxType {
         BoxType::MinfBox
     }
 
@@ -101,7 +101,7 @@ impl<R: Read + Seek> ReadBox<&mut R> for MinfBox {
 impl<W: Write> WriteBox<&mut W> for MinfBox {
     fn write_box(&self, writer: &mut W) -> Result<u64> {
         let size = self.box_size();
-        BoxHeader::new(Self::box_type(), size).write(writer)?;
+        BoxHeader::new(self.box_type(), size).write(writer)?;
 
         if let Some(ref vmhd) = self.vmhd {
             vmhd.write_box(writer)?;

--- a/src/mp4box/minf.rs
+++ b/src/mp4box/minf.rs
@@ -30,19 +30,11 @@ impl MinfBox {
 
 impl Mp4Box for MinfBox {
     fn box_type(&self) -> BoxType {
-        BoxType::MinfBox
+        return self.get_type();
     }
 
     fn box_size(&self) -> u64 {
-        let mut size = HEADER_SIZE;
-        if let Some(ref vmhd) = self.vmhd {
-            size += vmhd.box_size();
-        }
-        if let Some(ref smhd) = self.smhd {
-            size += smhd.box_size();
-        }
-        size += self.stbl.box_size();
-        size
+        return self.get_size();
     }
 }
 

--- a/src/mp4box/minf.rs
+++ b/src/mp4box/minf.rs
@@ -10,6 +10,24 @@ pub struct MinfBox {
     pub stbl: StblBox,
 }
 
+impl MinfBox {
+    pub fn get_type(&self) -> BoxType {
+        BoxType::MinfBox
+    }
+
+    pub fn get_size(&self) -> u64 {
+        let mut size = HEADER_SIZE;
+        if let Some(ref vmhd) = self.vmhd {
+            size += vmhd.box_size();
+        }
+        if let Some(ref smhd) = self.smhd {
+            size += smhd.box_size();
+        }
+        size += self.stbl.box_size();
+        size
+    }
+}
+
 impl Mp4Box for MinfBox {
     fn box_type() -> BoxType {
         BoxType::MinfBox

--- a/src/mp4box/mod.rs
+++ b/src/mp4box/mod.rs
@@ -99,7 +99,7 @@ boxtype! {
 }
 
 pub trait Mp4Box: Sized {
-    fn box_type() -> BoxType;
+    fn box_type(&self) -> BoxType;
     fn box_size(&self) -> u64;
 }
 

--- a/src/mp4box/moov.rs
+++ b/src/mp4box/moov.rs
@@ -9,6 +9,20 @@ pub struct MoovBox {
     pub traks: Vec<TrakBox>,
 }
 
+impl MoovBox {
+    pub fn get_type(&self) -> BoxType {
+        BoxType::MoovBox
+    }
+
+    pub fn get_size(&self) -> u64 {
+        let mut size = HEADER_SIZE + self.mvhd.box_size();
+        for trak in self.traks.iter() {
+            size += trak.box_size();
+        }
+        size
+    }
+}
+
 impl Mp4Box for MoovBox {
     fn box_type() -> BoxType {
         BoxType::MoovBox

--- a/src/mp4box/moov.rs
+++ b/src/mp4box/moov.rs
@@ -24,7 +24,7 @@ impl MoovBox {
 }
 
 impl Mp4Box for MoovBox {
-    fn box_type() -> BoxType {
+    fn box_type(&self) -> BoxType {
         BoxType::MoovBox
     }
 
@@ -88,7 +88,7 @@ impl<R: Read + Seek> ReadBox<&mut R> for MoovBox {
 impl<W: Write> WriteBox<&mut W> for MoovBox {
     fn write_box(&self, writer: &mut W) -> Result<u64> {
         let size = self.box_size();
-        BoxHeader::new(Self::box_type(), size).write(writer)?;
+        BoxHeader::new(self.box_type(), size).write(writer)?;
 
         self.mvhd.write_box(writer)?;
         for trak in self.traks.iter() {

--- a/src/mp4box/moov.rs
+++ b/src/mp4box/moov.rs
@@ -25,15 +25,11 @@ impl MoovBox {
 
 impl Mp4Box for MoovBox {
     fn box_type(&self) -> BoxType {
-        BoxType::MoovBox
+        return self.get_type();
     }
 
     fn box_size(&self) -> u64 {
-        let mut size = HEADER_SIZE + self.mvhd.box_size();
-        for trak in self.traks.iter() {
-            size += trak.box_size();
-        }
-        size
+        return self.get_size();
     }
 }
 

--- a/src/mp4box/mp4a.rs
+++ b/src/mp4box/mp4a.rs
@@ -50,15 +50,11 @@ impl Mp4aBox {
 
 impl Mp4Box for Mp4aBox {
     fn box_type(&self) -> BoxType {
-        BoxType::Mp4aBox
+        return self.get_type();
     }
 
     fn box_size(&self) -> u64 {
-        let mut size = HEADER_SIZE + 8 + 20;
-        if let Some(ref esds) = self.esds {
-            size += esds.box_size();
-        }
-        size
+        return self.get_size();
     }
 }
 

--- a/src/mp4box/mp4a.rs
+++ b/src/mp4box/mp4a.rs
@@ -34,6 +34,18 @@ impl Mp4aBox {
             esds: Some(EsdsBox::new(config)),
         }
     }
+
+    pub fn get_type(&self) -> BoxType {
+        BoxType::Mp4aBox
+    }
+
+    pub fn get_size(&self) -> u64 {
+        let mut size = HEADER_SIZE + 8 + 20;
+        if let Some(ref esds) = self.esds {
+            size += esds.box_size();
+        }
+        size
+    }
 }
 
 impl Mp4Box for Mp4aBox {

--- a/src/mp4box/mp4a.rs
+++ b/src/mp4box/mp4a.rs
@@ -49,7 +49,7 @@ impl Mp4aBox {
 }
 
 impl Mp4Box for Mp4aBox {
-    fn box_type() -> BoxType {
+    fn box_type(&self) -> BoxType {
         BoxType::Mp4aBox
     }
 
@@ -98,7 +98,7 @@ impl<R: Read + Seek> ReadBox<&mut R> for Mp4aBox {
 impl<W: Write> WriteBox<&mut W> for Mp4aBox {
     fn write_box(&self, writer: &mut W) -> Result<u64> {
         let size = self.box_size();
-        BoxHeader::new(Self::box_type(), size).write(writer)?;
+        BoxHeader::new(self.box_type(), size).write(writer)?;
 
         writer.write_u32::<BigEndian>(0)?; // reserved
         writer.write_u16::<BigEndian>(0)?; // reserved
@@ -136,7 +136,7 @@ impl EsdsBox {
 }
 
 impl Mp4Box for EsdsBox {
-    fn box_type() -> BoxType {
+    fn box_type(&self) -> BoxType {
         BoxType::EsdsBox
     }
 
@@ -183,7 +183,7 @@ impl<R: Read + Seek> ReadBox<&mut R> for EsdsBox {
 impl<W: Write> WriteBox<&mut W> for EsdsBox {
     fn write_box(&self, writer: &mut W) -> Result<u64> {
         let size = self.box_size();
-        BoxHeader::new(Self::box_type(), size).write(writer)?;
+        BoxHeader::new(self.box_type(), size).write(writer)?;
 
         write_box_header_ext(writer, self.version, self.flags)?;
 

--- a/src/mp4box/mvhd.rs
+++ b/src/mp4box/mvhd.rs
@@ -14,6 +14,24 @@ pub struct MvhdBox {
     pub rate: FixedPointU16,
 }
 
+impl MvhdBox {
+    pub fn get_type(&self) -> BoxType {
+        BoxType::MvhdBox
+    }
+
+    pub fn get_size(&self) -> u64 {
+        let mut size = HEADER_SIZE + HEADER_EXT_SIZE;
+        if self.version == 1 {
+            size += 28;
+        } else {
+            assert_eq!(self.version, 0);
+            size += 16;
+        }
+        size += 80;
+        size
+    }
+}
+
 impl Default for MvhdBox {
     fn default() -> Self {
         MvhdBox {

--- a/src/mp4box/mvhd.rs
+++ b/src/mp4box/mvhd.rs
@@ -48,19 +48,11 @@ impl Default for MvhdBox {
 
 impl Mp4Box for MvhdBox {
     fn box_type(&self) -> BoxType {
-        BoxType::MvhdBox
+        return self.get_type();
     }
 
     fn box_size(&self) -> u64 {
-        let mut size = HEADER_SIZE + HEADER_EXT_SIZE;
-        if self.version == 1 {
-            size += 28;
-        } else {
-            assert_eq!(self.version, 0);
-            size += 16;
-        }
-        size += 80;
-        size
+        return self.get_size();
     }
 }
 

--- a/src/mp4box/mvhd.rs
+++ b/src/mp4box/mvhd.rs
@@ -47,7 +47,7 @@ impl Default for MvhdBox {
 }
 
 impl Mp4Box for MvhdBox {
-    fn box_type() -> BoxType {
+    fn box_type(&self) -> BoxType {
         BoxType::MvhdBox
     }
 
@@ -105,7 +105,7 @@ impl<R: Read + Seek> ReadBox<&mut R> for MvhdBox {
 impl<W: Write> WriteBox<&mut W> for MvhdBox {
     fn write_box(&self, writer: &mut W) -> Result<u64> {
         let size = self.box_size();
-        BoxHeader::new(Self::box_type(), size).write(writer)?;
+        BoxHeader::new(self.box_type(), size).write(writer)?;
 
         write_box_header_ext(writer, self.version, self.flags)?;
 

--- a/src/mp4box/smhd.rs
+++ b/src/mp4box/smhd.rs
@@ -31,7 +31,7 @@ impl Default for SmhdBox {
 }
 
 impl Mp4Box for SmhdBox {
-    fn box_type() -> BoxType {
+    fn box_type(&self) -> BoxType {
         BoxType::SmhdBox
     }
 
@@ -61,7 +61,7 @@ impl<R: Read + Seek> ReadBox<&mut R> for SmhdBox {
 impl<W: Write> WriteBox<&mut W> for SmhdBox {
     fn write_box(&self, writer: &mut W) -> Result<u64> {
         let size = self.box_size();
-        BoxHeader::new(Self::box_type(), size).write(writer)?;
+        BoxHeader::new(self.box_type(), size).write(writer)?;
 
         write_box_header_ext(writer, self.version, self.flags)?;
 

--- a/src/mp4box/smhd.rs
+++ b/src/mp4box/smhd.rs
@@ -32,11 +32,11 @@ impl Default for SmhdBox {
 
 impl Mp4Box for SmhdBox {
     fn box_type(&self) -> BoxType {
-        BoxType::SmhdBox
+        return self.get_type();
     }
 
     fn box_size(&self) -> u64 {
-        HEADER_SIZE + HEADER_EXT_SIZE + 4
+        return self.get_size();
     }
 }
 

--- a/src/mp4box/smhd.rs
+++ b/src/mp4box/smhd.rs
@@ -10,6 +10,16 @@ pub struct SmhdBox {
     pub balance: FixedPointI8,
 }
 
+impl SmhdBox {
+    pub fn get_type(&self) -> BoxType {
+        BoxType::SmhdBox
+    }
+
+    pub fn get_size(&self) -> u64 {
+        HEADER_SIZE + HEADER_EXT_SIZE + 4
+    }
+}
+
 impl Default for SmhdBox {
     fn default() -> Self {
         SmhdBox {

--- a/src/mp4box/stbl.rs
+++ b/src/mp4box/stbl.rs
@@ -18,6 +18,33 @@ pub struct StblBox {
     pub co64: Option<Co64Box>,
 }
 
+impl StblBox {
+    pub fn get_type(&self) -> BoxType {
+        BoxType::StblBox
+    }
+
+    pub fn get_size(&self) -> u64 {
+        let mut size = HEADER_SIZE;
+        size += self.stsd.box_size();
+        size += self.stts.box_size();
+        if let Some(ref ctts) = self.ctts {
+            size += ctts.box_size();
+        }
+        if let Some(ref stss) = self.stss {
+            size += stss.box_size();
+        }
+        size += self.stsc.box_size();
+        size += self.stsz.box_size();
+        if let Some(ref stco) = self.stco {
+            size += stco.box_size();
+        }
+        if let Some(ref co64) = self.co64 {
+            size += co64.box_size();
+        }
+        size
+    }
+}
+
 impl Mp4Box for StblBox {
     fn box_type() -> BoxType {
         BoxType::StblBox

--- a/src/mp4box/stbl.rs
+++ b/src/mp4box/stbl.rs
@@ -47,28 +47,11 @@ impl StblBox {
 
 impl Mp4Box for StblBox {
     fn box_type(&self) -> BoxType {
-        BoxType::StblBox
+        return self.get_type();
     }
 
     fn box_size(&self) -> u64 {
-        let mut size = HEADER_SIZE;
-        size += self.stsd.box_size();
-        size += self.stts.box_size();
-        if let Some(ref ctts) = self.ctts {
-            size += ctts.box_size();
-        }
-        if let Some(ref stss) = self.stss {
-            size += stss.box_size();
-        }
-        size += self.stsc.box_size();
-        size += self.stsz.box_size();
-        if let Some(ref stco) = self.stco {
-            size += stco.box_size();
-        }
-        if let Some(ref co64) = self.co64 {
-            size += co64.box_size();
-        }
-        size
+        return self.get_size();
     }
 }
 

--- a/src/mp4box/stbl.rs
+++ b/src/mp4box/stbl.rs
@@ -46,7 +46,7 @@ impl StblBox {
 }
 
 impl Mp4Box for StblBox {
-    fn box_type() -> BoxType {
+    fn box_type(&self) -> BoxType {
         BoxType::StblBox
     }
 
@@ -159,7 +159,7 @@ impl<R: Read + Seek> ReadBox<&mut R> for StblBox {
 impl<W: Write> WriteBox<&mut W> for StblBox {
     fn write_box(&self, writer: &mut W) -> Result<u64> {
         let size = self.box_size();
-        BoxHeader::new(Self::box_type(), size).write(writer)?;
+        BoxHeader::new(self.box_type(), size).write(writer)?;
 
         self.stsd.write_box(writer)?;
         self.stts.write_box(writer)?;

--- a/src/mp4box/stco.rs
+++ b/src/mp4box/stco.rs
@@ -10,6 +10,16 @@ pub struct StcoBox {
     pub entries: Vec<u32>,
 }
 
+impl StcoBox {
+    pub fn get_type(&self) -> BoxType {
+        BoxType::StcoBox
+    }
+
+    pub fn get_size(&self) -> u64 {
+        HEADER_SIZE + HEADER_EXT_SIZE + 4 + (4 * self.entries.len() as u64)
+    }
+}
+
 impl Mp4Box for StcoBox {
     fn box_type() -> BoxType {
         BoxType::StcoBox

--- a/src/mp4box/stco.rs
+++ b/src/mp4box/stco.rs
@@ -22,11 +22,11 @@ impl StcoBox {
 
 impl Mp4Box for StcoBox {
     fn box_type(&self) -> BoxType {
-        BoxType::StcoBox
+        return self.get_type();
     }
 
     fn box_size(&self) -> u64 {
-        HEADER_SIZE + HEADER_EXT_SIZE + 4 + (4 * self.entries.len() as u64)
+        return self.get_size();
     }
 }
 

--- a/src/mp4box/stco.rs
+++ b/src/mp4box/stco.rs
@@ -21,7 +21,7 @@ impl StcoBox {
 }
 
 impl Mp4Box for StcoBox {
-    fn box_type() -> BoxType {
+    fn box_type(&self) -> BoxType {
         BoxType::StcoBox
     }
 
@@ -56,7 +56,7 @@ impl<R: Read + Seek> ReadBox<&mut R> for StcoBox {
 impl<W: Write> WriteBox<&mut W> for StcoBox {
     fn write_box(&self, writer: &mut W) -> Result<u64> {
         let size = self.box_size();
-        BoxHeader::new(Self::box_type(), size).write(writer)?;
+        BoxHeader::new(self.box_type(), size).write(writer)?;
 
         write_box_header_ext(writer, self.version, self.flags)?;
 

--- a/src/mp4box/stsc.rs
+++ b/src/mp4box/stsc.rs
@@ -30,11 +30,11 @@ pub struct StscEntry {
 
 impl Mp4Box for StscBox {
     fn box_type(&self) -> BoxType {
-        BoxType::StscBox
+        return self.get_type();
     }
 
     fn box_size(&self) -> u64 {
-        HEADER_SIZE + HEADER_EXT_SIZE + 4 + (12 * self.entries.len() as u64)
+        return self.get_size();
     }
 }
 

--- a/src/mp4box/stsc.rs
+++ b/src/mp4box/stsc.rs
@@ -10,6 +10,16 @@ pub struct StscBox {
     pub entries: Vec<StscEntry>,
 }
 
+impl StscBox {
+    pub fn get_type(&self) -> BoxType {
+        BoxType::StscBox
+    }
+
+    pub fn get_size(&self) -> u64 {
+        HEADER_SIZE + HEADER_EXT_SIZE + 4 + (12 * self.entries.len() as u64)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct StscEntry {
     pub first_chunk: u32,

--- a/src/mp4box/stsc.rs
+++ b/src/mp4box/stsc.rs
@@ -29,7 +29,7 @@ pub struct StscEntry {
 }
 
 impl Mp4Box for StscBox {
-    fn box_type() -> BoxType {
+    fn box_type(&self) -> BoxType {
         BoxType::StscBox
     }
 
@@ -82,7 +82,7 @@ impl<R: Read + Seek> ReadBox<&mut R> for StscBox {
 impl<W: Write> WriteBox<&mut W> for StscBox {
     fn write_box(&self, writer: &mut W) -> Result<u64> {
         let size = self.box_size();
-        BoxHeader::new(Self::box_type(), size).write(writer)?;
+        BoxHeader::new(self.box_type(), size).write(writer)?;
 
         write_box_header_ext(writer, self.version, self.flags)?;
 

--- a/src/mp4box/stsd.rs
+++ b/src/mp4box/stsd.rs
@@ -12,6 +12,22 @@ pub struct StsdBox {
     pub mp4a: Option<Mp4aBox>,
 }
 
+impl StsdBox {
+    pub fn get_type(&self) -> BoxType {
+        BoxType::StsdBox
+    }
+
+    pub fn get_size(&self) -> u64 {
+        let mut size = HEADER_SIZE + HEADER_EXT_SIZE + 4;
+        if let Some(ref avc1) = self.avc1 {
+            size += avc1.box_size();
+        } else if let Some(ref mp4a) = self.mp4a {
+            size += mp4a.box_size();
+        }
+        size
+    }
+}
+
 impl Mp4Box for StsdBox {
     fn box_type() -> BoxType {
         BoxType::StsdBox

--- a/src/mp4box/stsd.rs
+++ b/src/mp4box/stsd.rs
@@ -29,7 +29,7 @@ impl StsdBox {
 }
 
 impl Mp4Box for StsdBox {
-    fn box_type() -> BoxType {
+    fn box_type(&self) -> BoxType {
         BoxType::StsdBox
     }
 
@@ -83,7 +83,7 @@ impl<R: Read + Seek> ReadBox<&mut R> for StsdBox {
 impl<W: Write> WriteBox<&mut W> for StsdBox {
     fn write_box(&self, writer: &mut W) -> Result<u64> {
         let size = self.box_size();
-        BoxHeader::new(Self::box_type(), size).write(writer)?;
+        BoxHeader::new(self.box_type(), size).write(writer)?;
 
         write_box_header_ext(writer, self.version, self.flags)?;
 

--- a/src/mp4box/stsd.rs
+++ b/src/mp4box/stsd.rs
@@ -30,17 +30,11 @@ impl StsdBox {
 
 impl Mp4Box for StsdBox {
     fn box_type(&self) -> BoxType {
-        BoxType::StsdBox
+        return self.get_type();
     }
 
     fn box_size(&self) -> u64 {
-        let mut size = HEADER_SIZE + HEADER_EXT_SIZE + 4;
-        if let Some(ref avc1) = self.avc1 {
-            size += avc1.box_size();
-        } else if let Some(ref mp4a) = self.mp4a {
-            size += mp4a.box_size();
-        }
-        size
+        return self.get_size();
     }
 }
 

--- a/src/mp4box/stss.rs
+++ b/src/mp4box/stss.rs
@@ -22,11 +22,11 @@ impl StssBox {
 
 impl Mp4Box for StssBox {
     fn box_type(&self) -> BoxType {
-        BoxType::StssBox
+        return self.get_type();
     }
 
     fn box_size(&self) -> u64 {
-        HEADER_SIZE + HEADER_EXT_SIZE + 4 + (4 * self.entries.len() as u64)
+        return self.get_size();
     }
 }
 

--- a/src/mp4box/stss.rs
+++ b/src/mp4box/stss.rs
@@ -10,6 +10,16 @@ pub struct StssBox {
     pub entries: Vec<u32>,
 }
 
+impl StssBox {
+    pub fn get_type(&self) -> BoxType {
+        BoxType::StssBox
+    }
+
+    pub fn get_size(&self) -> u64 {
+        HEADER_SIZE + HEADER_EXT_SIZE + 4 + (4 * self.entries.len() as u64)
+    }
+}
+
 impl Mp4Box for StssBox {
     fn box_type() -> BoxType {
         BoxType::StssBox

--- a/src/mp4box/stss.rs
+++ b/src/mp4box/stss.rs
@@ -21,7 +21,7 @@ impl StssBox {
 }
 
 impl Mp4Box for StssBox {
-    fn box_type() -> BoxType {
+    fn box_type(&self) -> BoxType {
         BoxType::StssBox
     }
 
@@ -56,7 +56,7 @@ impl<R: Read + Seek> ReadBox<&mut R> for StssBox {
 impl<W: Write> WriteBox<&mut W> for StssBox {
     fn write_box(&self, writer: &mut W) -> Result<u64> {
         let size = self.box_size();
-        BoxHeader::new(Self::box_type(), size).write(writer)?;
+        BoxHeader::new(self.box_type(), size).write(writer)?;
 
         write_box_header_ext(writer, self.version, self.flags)?;
 

--- a/src/mp4box/stsz.rs
+++ b/src/mp4box/stsz.rs
@@ -23,7 +23,7 @@ impl StszBox {
 }
 
 impl Mp4Box for StszBox {
-    fn box_type() -> BoxType {
+    fn box_type(&self) -> BoxType {
         BoxType::StszBox
     }
 
@@ -63,7 +63,7 @@ impl<R: Read + Seek> ReadBox<&mut R> for StszBox {
 impl<W: Write> WriteBox<&mut W> for StszBox {
     fn write_box(&self, writer: &mut W) -> Result<u64> {
         let size = self.box_size();
-        BoxHeader::new(Self::box_type(), size).write(writer)?;
+        BoxHeader::new(self.box_type(), size).write(writer)?;
 
         write_box_header_ext(writer, self.version, self.flags)?;
 

--- a/src/mp4box/stsz.rs
+++ b/src/mp4box/stsz.rs
@@ -12,6 +12,16 @@ pub struct StszBox {
     pub sample_sizes: Vec<u32>,
 }
 
+impl StszBox {
+    pub fn get_type(&self) -> BoxType {
+        BoxType::StszBox
+    }
+
+    pub fn get_size(&self) -> u64 {
+        HEADER_SIZE + HEADER_EXT_SIZE + 8 + (4 * self.sample_sizes.len() as u64)
+    }
+}
+
 impl Mp4Box for StszBox {
     fn box_type() -> BoxType {
         BoxType::StszBox

--- a/src/mp4box/stsz.rs
+++ b/src/mp4box/stsz.rs
@@ -24,11 +24,11 @@ impl StszBox {
 
 impl Mp4Box for StszBox {
     fn box_type(&self) -> BoxType {
-        BoxType::StszBox
+        return self.get_type();
     }
 
     fn box_size(&self) -> u64 {
-        HEADER_SIZE + HEADER_EXT_SIZE + 8 + (4 * self.sample_sizes.len() as u64)
+        return self.get_size();
     }
 }
 

--- a/src/mp4box/stts.rs
+++ b/src/mp4box/stts.rs
@@ -27,7 +27,7 @@ pub struct SttsEntry {
 }
 
 impl Mp4Box for SttsBox {
-    fn box_type() -> BoxType {
+    fn box_type(&self) -> BoxType {
         BoxType::SttsBox
     }
 
@@ -65,7 +65,7 @@ impl<R: Read + Seek> ReadBox<&mut R> for SttsBox {
 impl<W: Write> WriteBox<&mut W> for SttsBox {
     fn write_box(&self, writer: &mut W) -> Result<u64> {
         let size = self.box_size();
-        BoxHeader::new(Self::box_type(), size).write(writer)?;
+        BoxHeader::new(self.box_type(), size).write(writer)?;
 
         write_box_header_ext(writer, self.version, self.flags)?;
 

--- a/src/mp4box/stts.rs
+++ b/src/mp4box/stts.rs
@@ -28,11 +28,11 @@ pub struct SttsEntry {
 
 impl Mp4Box for SttsBox {
     fn box_type(&self) -> BoxType {
-        BoxType::SttsBox
+        return self.get_type();
     }
 
     fn box_size(&self) -> u64 {
-        HEADER_SIZE + HEADER_EXT_SIZE + 4 + (8 * self.entries.len() as u64)
+        return self.get_size();
     }
 }
 

--- a/src/mp4box/stts.rs
+++ b/src/mp4box/stts.rs
@@ -10,6 +10,16 @@ pub struct SttsBox {
     pub entries: Vec<SttsEntry>,
 }
 
+impl SttsBox {
+    pub fn get_type(&self) -> BoxType {
+        BoxType::SttsBox
+    }
+
+    pub fn get_size(&self) -> u64 {
+        HEADER_SIZE + HEADER_EXT_SIZE + 4 + (8 * self.entries.len() as u64)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct SttsEntry {
     pub sample_count: u32,

--- a/src/mp4box/tkhd.rs
+++ b/src/mp4box/tkhd.rs
@@ -78,7 +78,7 @@ impl TkhdBox {
 }
 
 impl Mp4Box for TkhdBox {
-    fn box_type() -> BoxType {
+    fn box_type(&self) -> BoxType {
         BoxType::TkhdBox
     }
 
@@ -162,7 +162,7 @@ impl<R: Read + Seek> ReadBox<&mut R> for TkhdBox {
 impl<W: Write> WriteBox<&mut W> for TkhdBox {
     fn write_box(&self, writer: &mut W) -> Result<u64> {
         let size = self.box_size();
-        BoxHeader::new(Self::box_type(), size).write(writer)?;
+        BoxHeader::new(self.box_type(), size).write(writer)?;
 
         write_box_header_ext(writer, self.version, self.flags)?;
 

--- a/src/mp4box/tkhd.rs
+++ b/src/mp4box/tkhd.rs
@@ -79,19 +79,11 @@ impl TkhdBox {
 
 impl Mp4Box for TkhdBox {
     fn box_type(&self) -> BoxType {
-        BoxType::TkhdBox
+        return self.get_type();
     }
 
     fn box_size(&self) -> u64 {
-        let mut size = HEADER_SIZE + HEADER_EXT_SIZE;
-        if self.version == 1 {
-            size += 32;
-        } else {
-            assert_eq!(self.version, 0);
-            size += 20;
-        }
-        size += 60;
-        size
+        return self.get_size();
     }
 }
 

--- a/src/mp4box/tkhd.rs
+++ b/src/mp4box/tkhd.rs
@@ -52,6 +52,22 @@ pub struct Matrix {
 }
 
 impl TkhdBox {
+    pub fn get_type(&self) -> BoxType {
+        BoxType::TkhdBox
+    }
+
+    pub fn get_size(&self) -> u64 {
+        let mut size = HEADER_SIZE + HEADER_EXT_SIZE;
+        if self.version == 1 {
+            size += 32;
+        } else {
+            assert_eq!(self.version, 0);
+            size += 20;
+        }
+        size += 60;
+        size
+    }
+
     pub fn set_width(&mut self, width: u16) {
         self.width = FixedPointU16::new(width);
     }

--- a/src/mp4box/trak.rs
+++ b/src/mp4box/trak.rs
@@ -10,6 +10,22 @@ pub struct TrakBox {
     pub mdia: MdiaBox,
 }
 
+impl TrakBox {
+    pub fn get_type(&self) -> BoxType {
+        BoxType::TrakBox
+    }
+
+    pub fn get_size(&self) -> u64 {
+        let mut size = HEADER_SIZE;
+        size += self.tkhd.box_size();
+        if let Some(ref edts) = self.edts {
+            size += edts.box_size();
+        }
+        size += self.mdia.box_size();
+        size
+    }
+}
+
 impl Mp4Box for TrakBox {
     fn box_type() -> BoxType {
         BoxType::TrakBox

--- a/src/mp4box/trak.rs
+++ b/src/mp4box/trak.rs
@@ -27,7 +27,7 @@ impl TrakBox {
 }
 
 impl Mp4Box for TrakBox {
-    fn box_type() -> BoxType {
+    fn box_type(&self) -> BoxType {
         BoxType::TrakBox
     }
 
@@ -96,7 +96,7 @@ impl<R: Read + Seek> ReadBox<&mut R> for TrakBox {
 impl<W: Write> WriteBox<&mut W> for TrakBox {
     fn write_box(&self, writer: &mut W) -> Result<u64> {
         let size = self.box_size();
-        BoxHeader::new(Self::box_type(), size).write(writer)?;
+        BoxHeader::new(self.box_type(), size).write(writer)?;
 
         self.tkhd.write_box(writer)?;
         if let Some(ref edts) = self.edts {

--- a/src/mp4box/trak.rs
+++ b/src/mp4box/trak.rs
@@ -28,17 +28,11 @@ impl TrakBox {
 
 impl Mp4Box for TrakBox {
     fn box_type(&self) -> BoxType {
-        BoxType::TrakBox
+        return self.get_type();
     }
 
     fn box_size(&self) -> u64 {
-        let mut size = HEADER_SIZE;
-        size += self.tkhd.box_size();
-        if let Some(ref edts) = self.edts {
-            size += edts.box_size();
-        }
-        size += self.mdia.box_size();
-        size
+        return self.get_size();
     }
 }
 

--- a/src/mp4box/vmhd.rs
+++ b/src/mp4box/vmhd.rs
@@ -29,7 +29,7 @@ impl VmhdBox {
 }
 
 impl Mp4Box for VmhdBox {
-    fn box_type() -> BoxType {
+    fn box_type(&self) -> BoxType {
         BoxType::VmhdBox
     }
 
@@ -65,7 +65,7 @@ impl<R: Read + Seek> ReadBox<&mut R> for VmhdBox {
 impl<W: Write> WriteBox<&mut W> for VmhdBox {
     fn write_box(&self, writer: &mut W) -> Result<u64> {
         let size = self.box_size();
-        BoxHeader::new(Self::box_type(), size).write(writer)?;
+        BoxHeader::new(self.box_type(), size).write(writer)?;
 
         write_box_header_ext(writer, self.version, self.flags)?;
 

--- a/src/mp4box/vmhd.rs
+++ b/src/mp4box/vmhd.rs
@@ -18,6 +18,16 @@ pub struct RgbColor {
     pub blue: u16,
 }
 
+impl VmhdBox {
+    pub fn get_type(&self) -> BoxType {
+        BoxType::VmhdBox
+    }
+
+    pub fn get_size(&self) -> u64 {
+        HEADER_SIZE + HEADER_EXT_SIZE + 8
+    }
+}
+
 impl Mp4Box for VmhdBox {
     fn box_type() -> BoxType {
         BoxType::VmhdBox

--- a/src/mp4box/vmhd.rs
+++ b/src/mp4box/vmhd.rs
@@ -30,11 +30,11 @@ impl VmhdBox {
 
 impl Mp4Box for VmhdBox {
     fn box_type(&self) -> BoxType {
-        BoxType::VmhdBox
+        return self.get_type();
     }
 
     fn box_size(&self) -> u64 {
-        HEADER_SIZE + HEADER_EXT_SIZE + 8
+        return self.get_size();
     }
 }
 


### PR DESCRIPTION
* Add `mp4dump` example, which can be improved once we have box paths implemented.
* `get_type` and `get_size` methods to all mp4box implementations
* Add `mp4::read_mp4` top level public function, which is basically a wrapper over the Mp4Reader.